### PR TITLE
fix: hashnode api returning stale data

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2772,6 +2772,7 @@ const getQuery = (publicationName, limit) => {
       }
       edges {
         node {
+          id
           url
           title
           brief

--- a/src/hashnodeQuery.ts
+++ b/src/hashnodeQuery.ts
@@ -13,6 +13,7 @@ const getQuery = (publicationName: string, limit: number): string => {
       }
       edges {
         node {
+          id
           url
           title
           brief


### PR DESCRIPTION
# Description

This PR fixes the issue of hashnode API returning stale data by adding `id` attribute in the query.

Fixes #131 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

<!--- If you made any visual changes, include screenshot. -->
<!-- If you made any workflow changes, include a screenshare -->
<!--- If not relevant, delete this section. -->
